### PR TITLE
setBatteryLevel should be notified.

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP32 BLE Mouse",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Bluetooth LE Mouse library for the ESP32.",
   "keywords": "Bluetooth, BLE, HID, Mouse",
   "platforms": "espressif32",

--- a/src/BleMouse.cpp
+++ b/src/BleMouse.cpp
@@ -136,10 +136,12 @@ bool BleMouse::isConnected(void) const {
     return connected;
 }
 
-void BleMouse::setBatteryLevel(uint8_t level) {
+void BleMouse::setBatteryLevel(uint8_t level, bool notify); {
     this->batteryLevel = level;
     if (hid != 0)
         this->hid->setBatteryLevel(this->batteryLevel);
+        if (notify)
+            this->hid->batteryLevel()->notify();
 }
 
 void BleMouse::onConnect(NimBLEServer *pServer) {

--- a/src/BleMouse.cpp
+++ b/src/BleMouse.cpp
@@ -136,7 +136,7 @@ bool BleMouse::isConnected(void) const {
     return connected;
 }
 
-void BleMouse::setBatteryLevel(uint8_t level, bool notify); {
+void BleMouse::setBatteryLevel(uint8_t level, bool notify) {
     this->batteryLevel = level;
     if (hid != 0)
         this->hid->setBatteryLevel(this->batteryLevel);

--- a/src/BleMouse.h
+++ b/src/BleMouse.h
@@ -27,7 +27,7 @@ class BleMouse : protected NimBLEServerCallbacks {
     void release(uint8_t b = MOUSE_LEFT);          // release LEFT by default
     bool isPressed(uint8_t b = MOUSE_LEFT) const;  // check LEFT by default
     bool isConnected(void) const;
-    void setBatteryLevel(uint8_t level, bool notify);
+    void setBatteryLevel(uint8_t level, bool notify = false);
     void onConnect(Callback cb);
     void onDisconnect(Callback cb);
 

--- a/src/BleMouse.h
+++ b/src/BleMouse.h
@@ -27,7 +27,7 @@ class BleMouse : protected NimBLEServerCallbacks {
     void release(uint8_t b = MOUSE_LEFT);          // release LEFT by default
     bool isPressed(uint8_t b = MOUSE_LEFT) const;  // check LEFT by default
     bool isConnected(void) const;
-    void setBatteryLevel(uint8_t level);
+    void setBatteryLevel(uint8_t level, bool notify);
     void onConnect(Callback cb);
     void onDisconnect(Callback cb);
 


### PR DESCRIPTION
iPhone and Android devices updates their battery level passively, their value wont change without notifying, so I added an optional option to allow the battery level be notified.